### PR TITLE
Support OTP 28 in CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.2"
-          elixir-version: "1.18.1"
+          otp-version: "28.0.2"
+          elixir-version: "1.18.4"
           version-type: "strict"
       - uses: actions/cache@v4
         name: Cache
@@ -39,13 +39,13 @@ jobs:
     name: Test SDK on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "25.3.2.16"]
-        elixir_version: ["1.18.1", "1.14.5"]
+        otp_version: ["28.0.2", "25.3.2.21"]
+        elixir_version: ["1.18.4", "1.14.5"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
         exclude:
           - elixir_version: "1.14.5"
-          - otp_version: "27.2"
+          - otp_version: "28.0.2"
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir_version }}
@@ -67,13 +67,13 @@ jobs:
     name: Test API on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "25.3.2.16"]
-        elixir_version: ["1.18.1", "1.14.5"]
+        otp_version: ["28.0.2", "25.3.2.21"]
+        elixir_version: ["1.18.4", "1.14.5"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
         exclude:
           - elixir_version: "1.14.5"
-          - otp_version: "27.2"
+          - otp_version: "28.0.2"
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
       ELIXIR_VERSION: ${{ matrix.elixir_version }}
@@ -113,8 +113,8 @@ jobs:
     name: Dialyze on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2"]
-        elixir_version: ["1.18.1"]
+        otp_version: ["28.0.2"]
+        elixir_version: ["1.18.4"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     env:
@@ -150,13 +150,13 @@ jobs:
     name: Test SemConv on Elixir ${{ matrix.elixir_version }} (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "25.3.2.16"]
-        elixir_version: ["1.18.1", "1.14.5"]
+        otp_version: ["28.0.2", "25.3.2.21"]
+        elixir_version: ["1.18.4", "1.14.5"]
         rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
         exclude:
           - elixir_version: "1.14.5"
-          - otp_version: "27.2"
+          - otp_version: "28.0.2"
     defaults:
       run:
         working-directory: apps/opentelemetry_semantic_conventions

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ["28.0.2", "27.3.4.2", "26.2.5.14", "25.3.2.21"]
-        rebar3_version: ["3.25.1"]
+        rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ["28.0.2"]
-        rebar3_version: ["3.25.1"]
+        rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ["28.0.2"]
-        rebar3_version: ["3.25.1"]
+        rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
@@ -153,7 +153,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ["28.0.2", "25.3.2.21"]
-        rebar3_version: ["3.25.1"]
+        rebar3_version: ["3.24.0"]
         os: [ubuntu-24.04]
     defaults:
       run:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "26.2.5.6", "25.3.2.16"]
-        rebar3_version: ["3.24.0"]
+        otp_version: ["28.0.2", "27.3.4.2", "26.2.5.14", "25.3.2.21"]
+        rebar3_version: ["3.25.1"]
         os: [ubuntu-24.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
@@ -91,8 +91,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2"]
-        rebar3_version: ["3.24.0"]
+        otp_version: ["28.0.2"]
+        rebar3_version: ["3.25.1"]
         os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
@@ -119,8 +119,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2"]
-        rebar3_version: ["3.24.0"]
+        otp_version: ["28.0.2"]
+        rebar3_version: ["3.25.1"]
         os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v5
@@ -152,8 +152,8 @@ jobs:
     name: Test SemConv on (OTP ${{ matrix.otp_version }}) and ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["27.2", "25.3.2.16"]
-        rebar3_version: ["3.24.0"]
+        otp_version: ["28.0.2", "25.3.2.21"]
+        rebar3_version: ["3.25.1"]
         os: [ubuntu-24.04]
     defaults:
       run:


### PR DESCRIPTION
We also bump the existing Erlang/Elixir version to the latest release as well.